### PR TITLE
Update README & rename some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# napari-workflow-tasks
-Interact with workflow tasks in napari
+# napari-fractal-tasks
+Interact with fractal tasks in napari
+
+Prototype developed at the 2024 
+
+## Installation
+
+1. Set up an environment with napari and the plugin installed (mamba example):
+```
+git clone https://github.com/krentzd/napari-workflow-tasks/
+cd napari-workflow-tasks
+mamba create -n napari-fractal-task python=3.11 -y
+mamba activate napari-fractal-task
+mamba install napari pyqt
+pip install -e .
+```
+
+2. Install napari-ome-zarr (to be able to open OME-Zarrs in napari):
+```
+pip install napari-ome-zarr
+```
+
+3. Install the task packages you want to use:
+```
+pip install "fractal-tasks-core[fractal-tasks]"
+cd ../my_task_package_name
+pip install -e .
+```
+
+## Usage
+1. Open an OME-Zarr in napari (select the napari-ome-zarr plugin to open it)
+
+2. Open the napari Fractal task plugin
+
+3. Add a Fractal workflow package by providing the Fractal manifest json file. The task package needs to be installed in your Python environment that runs napari
+
+4. Select a task from the dropdown
+
+5. In the new tab, fill in all relevant parameters, then click `Execute task`.
+
+6. The plugin now runs the task in the background by loading the data from the on-disk OME-Zarr and saving the results back into that OME-Zarr. Based on a heuristic, it tries to load the result back into napari to show to the user.
+
+
+## Scope limits
+
+- Currently only works for Segmentation, Image Processing(?) and Measurement tasks
+- Requires tasks packages to be installed in the same environment as napari

--- a/README.md
+++ b/README.md
@@ -29,16 +29,23 @@ pip install -e .
 
 ## Usage
 1. Open an OME-Zarr in napari (select the napari-ome-zarr plugin to open it)
+<img width="144" alt="plugin_selection" src="https://github.com/user-attachments/assets/9a6914ab-16f7-4d3c-a042-44d8c5278eec" />
 
 2. Open the napari Fractal task plugin
 
+<img width="407" alt="open_plugin" src="https://github.com/user-attachments/assets/e0f92a32-e234-41ad-ab92-e9c9937100e6" />
+
+
 3. Add a Fractal workflow package by providing the Fractal manifest json file. The task package needs to be installed in your Python environment that runs napari
+
+<img width="990" alt="load_manifest" src="https://github.com/user-attachments/assets/d5516518-299d-4de9-be1f-6cb4c5e02e97" />
 
 4. Select a task from the dropdown
 
 5. In the new tab, fill in all relevant parameters, then click `Execute task`.
 
 6. The plugin now runs the task in the background by loading the data from the on-disk OME-Zarr and saving the results back into that OME-Zarr. Based on a heuristic, it tries to load the result back into napari to show to the user.
+<img width="1579" alt="napari_tasks_cellpose_zoom" src="https://github.com/user-attachments/assets/4b1eb82a-7e65-4b3f-9f38-9cf78e3ef878" />
 
 
 ## Scope limits

--- a/src/napari_workflow_tasks/_widget.py
+++ b/src/napari_workflow_tasks/_widget.py
@@ -273,7 +273,7 @@ class TasksQWidget(QWidget):
         self.workflow_adder_container = QWidget()
         self.workflow_adder_container.setLayout(QVBoxLayout())
 
-        self.workflow_adder_btn = QPushButton("Add workflow")
+        self.workflow_adder_btn = QPushButton("Add task package")
         self.workflow_adder_btn.clicked.connect(self._select_workflow_file)
         self.workflow_adder_container.layout().addWidget(self.workflow_adder_btn)
 

--- a/src/napari_workflow_tasks/napari.yaml
+++ b/src/napari_workflow_tasks/napari.yaml
@@ -38,4 +38,4 @@ contributions:
       key: unique_id.1
   widgets:
     - command: napari-workflow-tasks.make_qwidget
-      display_name: OME Tasks
+      display_name: Napari Fractal Task


### PR DESCRIPTION
Hey @krentzd 

While preparing screenshots for the hackathon preprint, I was running the plugin locally and thought I'd document how to install and use it. Here's a proposal for a README with it.

There were also 2 key labels in the interface I thought were confusing:
1. At the hackathon, we were thinking about calling them OME-tasks. For trademark reasons, I don't think we're allowed to do that. I suggest we call them Fractal tasks for now, as we also only support Fractal manifests
2. When loading a Fractal manifest, our nomenclature is calling them task packages, not workflows. Thus, I suggest we also update that here.

I didn't go deeper in the review, I'm sure we could add more polish to things. Looking forward to looking deeper into the code later, but thought we can already get the basic docs for it ready now :)